### PR TITLE
Add MVP password vault CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.eggs/
+*.log
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,47 @@
-# chatgptcodex
-chatgptcodex
+# password-vault
+
+MVP реализации "современного хранилища паролей" — утилита командной строки, 
+позволяющая создавать зашифрованный файл с паролями и управлять записями через
+простые команды.
+
+## Возможности
+
+- Создание нового хранилища с мастер-паролем (`password-vault <файл> init`).
+- Добавление, обновление и удаление записей с учётными данными.
+- Получение списка записей и просмотр конкретных секретов.
+- Шифрование записей при помощи Fernet (AES-128 + HMAC) с ключом, полученным
+  из мастер-пароля через Scrypt.
+
+## Установка
+
+```bash
+pip install .
+```
+
+Для разработки можно установить зависимости с поддержкой тестов:
+
+```bash
+pip install .[dev]
+```
+
+## Использование
+
+```bash
+# создать новое хранилище
+password-vault vault.json init
+
+# добавить запись
+password-vault vault.json add email --username user@example.com --url https://mail.example.com
+
+# показать запись
+password-vault vault.json show email
+
+# удалить запись
+password-vault vault.json remove email
+```
+
+## Тесты
+
+```bash
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "password-vault"
+version = "0.1.0"
+description = "MVP of a modern password storage CLI"
+authors = [{name = "ChatGPT"}]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "cryptography>=41,<43",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+]
+
+[project.scripts]
+password-vault = "password_vault.cli:main"

--- a/src/password_vault/__init__.py
+++ b/src/password_vault/__init__.py
@@ -1,0 +1,5 @@
+"""Password vault package."""
+
+from .vault import Vault
+
+__all__ = ["Vault"]

--- a/src/password_vault/cli.py
+++ b/src/password_vault/cli.py
@@ -1,0 +1,196 @@
+"""Command line interface for the password vault."""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import sys
+from pathlib import Path
+from typing import Callable
+
+from .vault import Entry, Vault, VaultError, VaultLockedError
+
+
+def prompt_new_master_password() -> str:
+    first = getpass.getpass("Enter a new master password: ")
+    second = getpass.getpass("Confirm the new master password: ")
+    if not first:
+        raise ValueError("Master password cannot be empty")
+    if first != second:
+        raise ValueError("Passwords do not match")
+    return first
+
+
+def prompt_master_password() -> str:
+    password = getpass.getpass("Master password: ")
+    if not password:
+        raise ValueError("Master password cannot be empty")
+    return password
+
+
+def prompt_entry_password() -> str:
+    password = getpass.getpass("Entry password: ")
+    if not password:
+        raise ValueError("Entry password cannot be empty")
+    return password
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Manage an encrypted password vault")
+    parser.add_argument("vault", help="Path to the vault file")
+
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init", help="Create a new vault")
+    init_parser.add_argument("--overwrite", action="store_true", help="Overwrite existing vault")
+    init_parser.set_defaults(func=handle_init)
+
+    list_parser = subparsers.add_parser("list", help="List stored entries")
+    list_parser.set_defaults(func=handle_list)
+
+    add_parser = subparsers.add_parser("add", help="Add or update an entry")
+    add_parser.add_argument("name", help="Name of the entry")
+    add_parser.add_argument("--username", required=True, help="Username for the entry")
+    add_parser.add_argument("--password", help="Password value; prompted if omitted")
+    add_parser.add_argument("--url", help="Related URL", default=None)
+    add_parser.add_argument("--notes", help="Additional notes", default=None)
+    add_parser.add_argument("--overwrite", action="store_true", help="Allow updating existing entries")
+    add_parser.set_defaults(func=handle_add)
+
+    show_parser = subparsers.add_parser("show", help="Display an entry")
+    show_parser.add_argument("name", help="Name of the entry")
+    show_parser.set_defaults(func=handle_show)
+
+    remove_parser = subparsers.add_parser("remove", help="Delete an entry")
+    remove_parser.add_argument("name", help="Name of the entry")
+    remove_parser.add_argument("--force", action="store_true", help="Do not ask for confirmation")
+    remove_parser.set_defaults(func=handle_remove)
+
+    return parser
+
+
+def handle_init(args: argparse.Namespace) -> None:
+    vault = Vault(Path(args.vault))
+    try:
+        password = prompt_new_master_password()
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(1)
+
+    try:
+        vault.initialize(password, overwrite=args.overwrite)
+    except FileExistsError:
+        print("Vault already exists. Use --overwrite to replace it.", file=sys.stderr)
+        raise SystemExit(1)
+    else:
+        print(f"Vault created at {vault.path}")
+
+
+def handle_list(args: argparse.Namespace) -> None:
+    vault = Vault(Path(args.vault))
+    master_password = _prompt_password_with_exit()
+    try:
+        entries = vault.list_entries(master_password)
+    except (VaultError, VaultLockedError, FileNotFoundError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(1)
+
+    if not entries:
+        print("Vault is empty")
+    else:
+        for name in entries:
+            print(name)
+
+
+def handle_add(args: argparse.Namespace) -> None:
+    vault = Vault(Path(args.vault))
+    master_password = _prompt_password_with_exit()
+
+    entry_password = args.password
+    if entry_password is None:
+        try:
+            entry_password = prompt_entry_password()
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            raise SystemExit(1)
+
+    try:
+        vault.add_entry(
+            master_password,
+            args.name,
+            username=args.username,
+            password=entry_password,
+            url=args.url,
+            notes=args.notes,
+            overwrite=args.overwrite,
+        )
+    except (VaultError, VaultLockedError, FileNotFoundError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(1)
+    else:
+        print(f"Entry '{args.name}' saved")
+
+
+def handle_show(args: argparse.Namespace) -> None:
+    vault = Vault(Path(args.vault))
+    master_password = _prompt_password_with_exit()
+
+    try:
+        entry = vault.get_entry(master_password, args.name)
+    except (VaultError, VaultLockedError, FileNotFoundError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(1)
+
+    _print_entry(entry)
+
+
+def handle_remove(args: argparse.Namespace) -> None:
+    vault = Vault(Path(args.vault))
+    master_password = _prompt_password_with_exit()
+
+    if not args.force:
+        confirmation = input(f"Delete entry '{args.name}'? [y/N]: ").strip().lower()
+        if confirmation not in {"y", "yes"}:
+            print("Aborted")
+            return
+
+    try:
+        vault.remove_entry(master_password, args.name)
+    except (VaultError, VaultLockedError, FileNotFoundError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(1)
+    else:
+        print(f"Entry '{args.name}' removed")
+
+
+def _prompt_password_with_exit() -> str:
+    try:
+        return prompt_master_password()
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(1)
+
+
+def _print_entry(entry: Entry) -> None:
+    print(f"Name: {entry.name}")
+    print(f"Username: {entry.username}")
+    print(f"Password: {entry.password}")
+    if entry.url:
+        print(f"URL: {entry.url}")
+    if entry.notes:
+        print(f"Notes: {entry.notes}")
+    if entry.created_at:
+        print(f"Created: {entry.created_at.isoformat()}")
+    if entry.updated_at:
+        print(f"Updated: {entry.updated_at.isoformat()}")
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    func: Callable[[argparse.Namespace], None] = getattr(args, "func")
+    func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/src/password_vault/crypto.py
+++ b/src/password_vault/crypto.py
@@ -1,0 +1,106 @@
+"""Utilities for key derivation and encryption."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+from dataclasses import dataclass
+from typing import Final
+
+from cryptography.fernet import Fernet, InvalidToken
+
+DEFAULT_SCRYPT_N: Final[int] = 2**14
+DEFAULT_SCRYPT_R: Final[int] = 8
+DEFAULT_SCRYPT_P: Final[int] = 1
+KEY_LENGTH: Final[int] = 32
+SALT_LENGTH: Final[int] = 16
+
+
+@dataclass(frozen=True)
+class KDFConfig:
+    """Configuration used to derive encryption keys."""
+
+    salt: bytes
+    n: int = DEFAULT_SCRYPT_N
+    r: int = DEFAULT_SCRYPT_R
+    p: int = DEFAULT_SCRYPT_P
+
+    def to_dict(self) -> dict[str, int | str]:
+        return {
+            "name": "scrypt",
+            "salt": base64.urlsafe_b64encode(self.salt).decode("ascii"),
+            "n": self.n,
+            "r": self.r,
+            "p": self.p,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, int | str]) -> "KDFConfig":
+        if data.get("name") != "scrypt":
+            raise ValueError("Unsupported KDF")
+        salt_b64 = data.get("salt")
+        if not isinstance(salt_b64, str):
+            raise ValueError("Invalid salt in config")
+        return cls(
+            salt=base64.urlsafe_b64decode(salt_b64.encode("ascii")),
+            n=int(data.get("n", DEFAULT_SCRYPT_N)),
+            r=int(data.get("r", DEFAULT_SCRYPT_R)),
+            p=int(data.get("p", DEFAULT_SCRYPT_P)),
+        )
+
+
+def generate_salt() -> bytes:
+    """Generate a random salt."""
+
+    return secrets.token_bytes(SALT_LENGTH)
+
+
+def derive_key(password: str, config: KDFConfig) -> bytes:
+    """Derive an encryption key from the provided password and configuration."""
+
+    raw_key = hashlib.scrypt(
+        password=password.encode("utf-8"),
+        salt=config.salt,
+        n=config.n,
+        r=config.r,
+        p=config.p,
+        dklen=KEY_LENGTH,
+    )
+    return base64.urlsafe_b64encode(raw_key)
+
+
+def build_cipher(password: str, config: KDFConfig) -> Fernet:
+    """Create a Fernet cipher for the given password and configuration."""
+
+    key = derive_key(password, config)
+    return Fernet(key)
+
+
+def encrypt(fernet: Fernet, data: bytes) -> str:
+    """Encrypt bytes and return a base64 encoded string."""
+
+    token = fernet.encrypt(data)
+    return token.decode("ascii")
+
+
+def decrypt(fernet: Fernet, token: str) -> bytes:
+    """Decrypt a base64 encoded string."""
+
+    try:
+        return fernet.decrypt(token.encode("ascii"))
+    except InvalidToken as exc:  # pragma: no cover - re-raised for clarity
+        raise ValueError("Invalid encryption token") from exc
+
+
+__all__ = [
+    "KDFConfig",
+    "DEFAULT_SCRYPT_N",
+    "DEFAULT_SCRYPT_R",
+    "DEFAULT_SCRYPT_P",
+    "generate_salt",
+    "derive_key",
+    "build_cipher",
+    "encrypt",
+    "decrypt",
+]

--- a/src/password_vault/vault.py
+++ b/src/password_vault/vault.py
@@ -1,0 +1,211 @@
+"""Vault management logic."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from cryptography.fernet import Fernet
+
+from .crypto import KDFConfig, build_cipher, decrypt, encrypt, generate_salt
+
+VAULT_VERSION = 1
+VERIFICATION_PLAINTEXT = b"password-vault"
+
+
+class VaultError(Exception):
+    """Base class for vault related errors."""
+
+
+class VaultLockedError(VaultError):
+    """Raised when the master password is incorrect."""
+
+
+@dataclass
+class Entry:
+    """Plaintext representation of a vault entry."""
+
+    name: str
+    username: str
+    password: str
+    url: str | None = None
+    notes: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "username": self.username,
+            "password": self.password,
+            "url": self.url,
+            "notes": self.notes,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Entry":
+        created_at = (
+            datetime.fromisoformat(data["created_at"]).astimezone(timezone.utc)
+            if data.get("created_at")
+            else None
+        )
+        updated_at = (
+            datetime.fromisoformat(data["updated_at"]).astimezone(timezone.utc)
+            if data.get("updated_at")
+            else None
+        )
+        return cls(
+            name=data["name"],
+            username=data["username"],
+            password=data["password"],
+            url=data.get("url"),
+            notes=data.get("notes"),
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+
+
+class Vault:
+    """Represents a password vault stored on disk."""
+
+    def __init__(self, path: str | Path):
+        self.path = Path(path)
+
+    # ------------------------------------------------------------------
+    # Vault lifecycle
+    # ------------------------------------------------------------------
+    def exists(self) -> bool:
+        return self.path.exists()
+
+    def initialize(self, master_password: str, *, overwrite: bool = False) -> None:
+        """Create a new vault file."""
+
+        if self.exists() and not overwrite:
+            raise FileExistsError(f"Vault already exists: {self.path}")
+
+        config = KDFConfig(salt=generate_salt())
+        cipher = build_cipher(master_password, config)
+        verification = encrypt(cipher, VERIFICATION_PLAINTEXT)
+
+        data = {
+            "version": VAULT_VERSION,
+            "kdf": config.to_dict(),
+            "verification": verification,
+            "entries": {},
+        }
+
+        self._write(data)
+
+    # ------------------------------------------------------------------
+    # High level operations
+    # ------------------------------------------------------------------
+    def list_entries(self, master_password: str) -> list[str]:
+        data, _ = self._load_and_unlock(master_password)
+        return sorted(data.get("entries", {}).keys())
+
+    def add_entry(
+        self,
+        master_password: str,
+        name: str,
+        username: str,
+        password: str,
+        *,
+        url: str | None = None,
+        notes: str | None = None,
+        overwrite: bool = False,
+    ) -> None:
+        data, cipher = self._load_and_unlock(master_password)
+
+        entries: dict[str, Any] = data.setdefault("entries", {})
+        now = datetime.now(timezone.utc)
+
+        if name in entries and not overwrite:
+            raise VaultError(f"Entry '{name}' already exists")
+
+        created_at = now
+        existing = entries.get(name)
+        if existing and existing.get("created_at"):
+            created_at = datetime.fromisoformat(existing["created_at"])
+
+        entry_data = Entry(
+            name=name,
+            username=username,
+            password=password,
+            url=url,
+            notes=notes,
+            created_at=created_at,
+            updated_at=now,
+        )
+
+        payload = json.dumps(entry_data.to_dict()).encode("utf-8")
+        encrypted = encrypt(cipher, payload)
+
+        entries[name] = {
+            "payload": encrypted,
+            "created_at": created_at.isoformat(),
+            "updated_at": now.isoformat(),
+        }
+
+        self._write(data)
+
+    def get_entry(self, master_password: str, name: str) -> Entry:
+        data, cipher = self._load_and_unlock(master_password)
+        entries: dict[str, Any] = data.get("entries", {})
+        if name not in entries:
+            raise VaultError(f"Entry '{name}' not found")
+
+        record = entries[name]
+        payload = decrypt(cipher, record["payload"])
+        entry_dict = json.loads(payload.decode("utf-8"))
+        entry = Entry.from_dict(entry_dict)
+        entry.created_at = (
+            datetime.fromisoformat(record["created_at"]).astimezone(timezone.utc)
+            if record.get("created_at")
+            else None
+        )
+        entry.updated_at = (
+            datetime.fromisoformat(record["updated_at"]).astimezone(timezone.utc)
+            if record.get("updated_at")
+            else None
+        )
+        return entry
+
+    def remove_entry(self, master_password: str, name: str) -> None:
+        data, _ = self._load_and_unlock(master_password)
+        entries: dict[str, Any] = data.get("entries", {})
+        if name not in entries:
+            raise VaultError(f"Entry '{name}' not found")
+        del entries[name]
+        self._write(data)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _load_and_unlock(self, master_password: str) -> tuple[dict[str, Any], Fernet]:
+        data = self._read()
+        config = KDFConfig.from_dict(data["kdf"])
+        cipher = build_cipher(master_password, config)
+        try:
+            decrypted = decrypt(cipher, data["verification"])
+        except ValueError as exc:  # pragma: no cover - explicit error
+            raise VaultLockedError("Incorrect master password") from exc
+        if decrypted != VERIFICATION_PLAINTEXT:
+            raise VaultError("Vault verification failed")
+        return data, cipher
+
+    def _read(self) -> dict[str, Any]:
+        if not self.exists():
+            raise FileNotFoundError(f"Vault not found: {self.path}")
+        raw = self.path.read_text("utf-8")
+        return json.loads(raw)
+
+    def _write(self, data: dict[str, Any]) -> None:
+        self.path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+
+
+__all__ = ["Vault", "VaultError", "VaultLockedError", "Entry"]

--- a/tests/test_vault.py
+++ b/tests/test_vault.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from password_vault.vault import Entry, Vault, VaultError, VaultLockedError
+
+
+@pytest.fixture()
+def vault_path(tmp_path: Path) -> Path:
+    return tmp_path / "vault.json"
+
+
+@pytest.fixture()
+def vault(vault_path: Path) -> Vault:
+    v = Vault(vault_path)
+    v.initialize("master-password")
+    return v
+
+
+def test_initialize_creates_vault_file(vault_path: Path) -> None:
+    vault = Vault(vault_path)
+    vault.initialize("secret")
+    assert vault.exists()
+
+    with vault_path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    assert data["version"] == 1
+    assert data["entries"] == {}
+
+
+def test_list_returns_entry_names(vault: Vault) -> None:
+    assert vault.list_entries("master-password") == []
+    vault.add_entry("master-password", "email", username="user", password="pwd")
+    vault.add_entry("master-password", "bank", username="banker", password="secure")
+    assert vault.list_entries("master-password") == ["bank", "email"]
+
+
+def test_add_and_get_entry(vault: Vault) -> None:
+    vault.add_entry(
+        "master-password",
+        "github",
+        username="octocat",
+        password="token",
+        url="https://github.com",
+        notes="2FA enabled",
+    )
+    entry = vault.get_entry("master-password", "github")
+    assert isinstance(entry, Entry)
+    assert entry.name == "github"
+    assert entry.username == "octocat"
+    assert entry.password == "token"
+    assert entry.url == "https://github.com"
+    assert entry.notes == "2FA enabled"
+    assert entry.created_at is not None
+    assert entry.updated_at is not None
+
+
+def test_add_requires_overwrite(vault: Vault) -> None:
+    vault.add_entry("master-password", "email", username="user", password="pwd")
+    with pytest.raises(VaultError):
+        vault.add_entry("master-password", "email", username="user", password="pwd")
+
+    vault.add_entry(
+        "master-password",
+        "email",
+        username="user",
+        password="new",
+        overwrite=True,
+    )
+    entry = vault.get_entry("master-password", "email")
+    assert entry.password == "new"
+
+
+def test_remove_entry(vault: Vault) -> None:
+    vault.add_entry("master-password", "email", username="user", password="pwd")
+    vault.remove_entry("master-password", "email")
+    assert vault.list_entries("master-password") == []
+    with pytest.raises(VaultError):
+        vault.get_entry("master-password", "email")
+
+
+def test_incorrect_master_password(vault: Vault) -> None:
+    with pytest.raises(VaultLockedError):
+        vault.list_entries("wrong")
+
+    vault.add_entry("master-password", "email", username="user", password="pwd")
+    with pytest.raises(VaultLockedError):
+        vault.get_entry("wrong", "email")


### PR DESCRIPTION
## Summary
- scaffold a Python package with CLI entry point for managing encrypted password vault files
- implement Fernet-based encryption, Scrypt key derivation, and vault operations with list/add/show/remove commands
- add pytest coverage for initialization, entry lifecycle, and password validation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0ff92f1ec833390022e46832cb126